### PR TITLE
removed duplicate `keywords: {` keyed dictionary

### DIFF
--- a/iecst.js
+++ b/iecst.js
@@ -20,7 +20,6 @@ function hljsDefineIECST(hljs) {
         name: "Structured Text",
         case_insensitive: true,
         keywords: {
-            keywords: {
                 keyword:
                     "if then end_if elsif else case of end_case " +
                     "to do by while repeat end_while end_repeat for end_for from " +


### PR DESCRIPTION
I realized while testing that there appears to be a duplicate `keywords: {` under the `keywords: {` dictionary item. This PR removes that item.