### PR TITLE
added iec-61131-3 conversion function support

### DIFF
--- a/iecst.js
+++ b/iecst.js
@@ -52,6 +52,16 @@ function hljsDefineIECST(hljs) {
                 relevance: 0
             },
             {
+                // Conversion Functions *_TO_**
+                className: "built_in",
+                begin: "(ANY|BOOL|BYTE|D?L?WORD|L?TIME|DATE|DT|TOD|W?CHAR|W?STRING|U?S?D?L?INT|L?REAL)_TO_(BOOL|BYTE|D?L?WORD|L?TIME|DATE|DT|TOD|W?CHAR|W?STRING|U?S?D?L?INT|L?REAL)"
+            },
+            {
+                // Conversion Functions TO_**
+                className: "built_in",
+                begin: "TO_(BOOL|BYTE|D?L?WORD|L?TIME|DATE|DT|TOD|W?CHAR|W?STRING|U?S?D?L?INT|L?REAL)"
+            },
+            {
                 className: "symbol",
                 begin: "(D|T|DT|TOD)#[0-9:\\-_shmyd]*"
             },


### PR DESCRIPTION
As suggested in this issue (#12) this pull request adds highlighting support for IEC 61131-3 conversion functions (such as `BYTE_TO_BOOL` and others).