### PR TITLE
Please remove the confusable instruction about Marp

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,26 +87,3 @@ class Highlighter extends Component
 
 export default Highlighter;
 ```
-
-## Example in Markdown-Generated Presentation
-#### (using [marp](https://marp.app/))
-
-Craft the IEC 61131 code that is desired and wrap it in a code-block defined with the tripple-backtick (`` ``` ``) and language as `iecst`.
-
-````markdown
-```iecst
-VAR
-    test : BOOL := TRUE ;
-    x : REAL := 5.23;
-    lx : LREAL;
-    myString : STRING(255) := 'this is a test string';
-END_VAR
-IF test THEN
-    lx := REAL_TO_LREAL( COS(x) );
-END_IF
-```
-````
-
-This will thus render as:
-
-![IEC 61131-3 Example](./61131example.png)


### PR DESCRIPTION
Hi, I'm a maintainer of [Marp](https://marp.app) that is mentioned in [the current README](https://github.com/highlightjs/highlightjs-structured-text/blob/aee31977143704f1caf7a8be8ac877542fec42ee/README.md#example-in-markdown-generated-presentation).

Marp is supporting only the core languages in highlight.js and **has never contained any support of extra languages provided by 3rd-party plugins**. The current README looks as if Marp has a native support of code highlight for `iecst` but _this is not true_. I'm worried this instruction makes misleading and confusion to our users.

As same as said @joshgoebel in https://github.com/highlightjs/highlightjs-structured-text/issues/15#issuecomment-766397462, Marp team also have the same view: it's a users responsibility to install not core languages into our tool.

And I think how to use in a specific tool which is not familiar to the most of highlight.js users should describe in that tool, not in this plugin. _Please not include the useless information for 99%+ users of highlight.js._

BTW, I've already described how to install this plugin into Marp in https://github.com/highlightjs/highlightjs-structured-text/issues/9#issuecomment-686326994.